### PR TITLE
redirect to DC domain

### DIFF
--- a/R-ecology-lesson-alternative/index.html
+++ b/R-ecology-lesson-alternative/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Redirect to https://datacarpentry.org/R-ecology-lesson-alternative/</title>
+    <meta http-equiv="refresh" content="0; url=https://datacarpentry.org/R-ecology-lesson-alternative/">
+  </head>
+  <body>
+    <p>Redirecting to <a 
+href="https://datacarpentry.org/R-ecology-lesson-alternative/">https://datacarpentry.org/R-ecology-lesson-alternative/</a>...</p>
+  </body>
+</html>


### PR DESCRIPTION
Redirect visitors to the old location of the redesigned R Ecology lesson